### PR TITLE
Fixed bug on Swing view

### DIFF
--- a/io.github.davidedelbimbo.music-store/src/it/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreViewIT.java
+++ b/io.github.davidedelbimbo.music-store/src/it/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreViewIT.java
@@ -230,9 +230,8 @@ public class MusicStoreViewIT extends AssertJSwingJUnitTestCase {
 		// Add a playlist to the repository and show it in the view.
 		Playlist playlistToUpdate = new Playlist(PLAYLIST_1_NAME, Arrays.asList(songToAdd));
 		musicStoreRepository.createPlaylist(playlistToUpdate);
-		GuiActionRunner.execute(() -> {
-			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate);
-		});
+		GuiActionRunner.execute(() -> 
+			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate));
 
 		window.list(LIST_SONGS_IN_STORE).selectItem(0);
 		window.button(BTN_ADD_TO_PLAYLIST).click();
@@ -254,9 +253,8 @@ public class MusicStoreViewIT extends AssertJSwingJUnitTestCase {
 		// Create a playlist and show it in the view.
 		Playlist playlistToUpdate = new Playlist(PLAYLIST_1_NAME, Arrays.asList(songToRemove));
 		musicStoreRepository.createPlaylist(playlistToUpdate);
-		GuiActionRunner.execute(() -> {
-			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate);
-		});
+		GuiActionRunner.execute(() ->
+			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate));
 
 		window.list(LIST_SONGS_IN_PLAYLIST).selectItem(0);
 		window.button(BTN_REMOVE_FROM_PLAYLIST).click();
@@ -267,19 +265,17 @@ public class MusicStoreViewIT extends AssertJSwingJUnitTestCase {
 
 	@Test @GUITest
 	public void testRemoveSongFromPlaylistButtonFails() {
-		// Add a song to the repository and show it in the view but not in the playlist.
-		Song songToRemove = new Song(SONG_1_ID, SONG_1_TITLE, SONG_1_ARTIST);
-		musicStoreRepository.addSong(songToRemove);
-		GuiActionRunner.execute(() -> {
-			musicStoreSwingView.getListSongsInStoreModel().addElement(songToRemove);
-			musicStoreSwingView.getListSongsInPlaylistModel().addElement(songToRemove);
-		});
-
 		// Create a playlist and show it in the view.
 		Playlist playlistToUpdate = new Playlist(PLAYLIST_1_NAME);
 		musicStoreRepository.createPlaylist(playlistToUpdate);
+		GuiActionRunner.execute(() -> 
+			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate));
+
+		// Add a song to the repository and show it in the view.
+		Song songToRemove = new Song(SONG_1_ID, SONG_1_TITLE, SONG_1_ARTIST);
+		musicStoreRepository.addSong(songToRemove);
 		GuiActionRunner.execute(() -> {
-			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(playlistToUpdate);
+			musicStoreSwingView.getListSongsInPlaylistModel().addElement(songToRemove);
 		});
 
 		window.list(LIST_SONGS_IN_PLAYLIST).selectItem(0);

--- a/io.github.davidedelbimbo.music-store/src/main/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingView.java
+++ b/io.github.davidedelbimbo.music-store/src/main/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingView.java
@@ -69,7 +69,7 @@ public class MusicStoreSwingView extends JFrame implements MusicStoreView {
 		return listSongsInPlaylistModel;
 	}
 
-	void setMusicStoreController(MusicStoreController musicStoreController) {
+	public void setMusicStoreController(MusicStoreController musicStoreController) {
 		this.musicStoreController = musicStoreController;
 		this.createPlaylistDialog.setMusicStoreController(musicStoreController);
 	}
@@ -182,7 +182,9 @@ public class MusicStoreSwingView extends JFrame implements MusicStoreView {
 			toggleAddToPlaylistButton();
 
 			// Selecting a song in store list should clear the selection in playlist list.
-			listSongsInPlaylist.clearSelection();
+			if (listSongsInStore.getSelectedIndex() != -1) {
+				listSongsInPlaylist.clearSelection();
+			}
 		});
 
 		scrollPaneSongsInPlaylist = new JScrollPane();
@@ -206,7 +208,9 @@ public class MusicStoreSwingView extends JFrame implements MusicStoreView {
 			toggleRemoveFromPlaylistButton();
 
 			// Selecting a song in playlist list should clear the selection in store list.
-			listSongsInStore.clearSelection();
+			if (listSongsInPlaylist.getSelectedIndex() != -1) {
+				listSongsInStore.clearSelection();
+			}
 		});
 
 		btnAddToPlaylist = new JButton("Add to playlist");

--- a/io.github.davidedelbimbo.music-store/src/main/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingView.java
+++ b/io.github.davidedelbimbo.music-store/src/main/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingView.java
@@ -122,13 +122,11 @@ public class MusicStoreSwingView extends JFrame implements MusicStoreView {
 			toggleAddToPlaylistButton();
 			toggleRemoveFromPlaylistButton();
 
-			if (comboBoxPlaylists.getSelectedIndex() != -1) {
-				// Display all songs in selected playlist.
-				Playlist playlist = (Playlist) comboBoxPlaylists.getSelectedItem();
+			listSongsInPlaylistModel.clear();
+			Playlist playlist = (Playlist) comboBoxPlaylists.getSelectedItem();
+			if (playlist != null) {
+				// Display songs in selected playlist.
 				musicStoreController.allSongsInPlaylist(playlist);
-			} else {
-				// Clear the list of songs in playlist.
-				listSongsInPlaylistModel.clear();
 			}
 		});
 

--- a/io.github.davidedelbimbo.music-store/src/test/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingViewTest.java
+++ b/io.github.davidedelbimbo.music-store/src/test/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingViewTest.java
@@ -150,11 +150,14 @@ public class MusicStoreSwingViewTest extends AssertJSwingJUnitTestCase {
 	}
 
 	@Test @GUITest
-	public void testUnselectingAPlaylistShouldClearThePlaylistList() {
-		GuiActionRunner.execute(() -> 
-			musicStoreSwingView.getListSongsInPlaylistModel().addElement(new Song(SONG_1_ID, SONG_1_TITLE, SONG_1_ARTIST)));
+	public void testChangingPlaylistShouldClearTheSongsInPlaylistList() {
+		GuiActionRunner.execute(() -> {
+			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(new Playlist(PLAYLIST_1_NAME));
+			musicStoreSwingView.getComboBoxPlaylistsModel().addElement(new Playlist(PLAYLIST_2_NAME));
+			musicStoreSwingView.getListSongsInPlaylistModel().addElement(new Song(SONG_1_ID, SONG_1_TITLE, SONG_1_ARTIST));
+		});
 
-		window.comboBox(COMBO_BOX_PLAYLISTS).clearSelection();
+		window.comboBox(COMBO_BOX_PLAYLISTS).selectItem(PLAYLIST_2_NAME);
 		window.list(LIST_SONGS_IN_PLAYLIST).requireItemCount(0);
 	}
 

--- a/io.github.davidedelbimbo.music-store/src/test/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingViewTest.java
+++ b/io.github.davidedelbimbo.music-store/src/test/java/io/github/davidedelbimbo/music_store/view/swing/MusicStoreSwingViewTest.java
@@ -168,6 +168,7 @@ public class MusicStoreSwingViewTest extends AssertJSwingJUnitTestCase {
 		window.list(LIST_SONGS_IN_STORE).selectItem(0);
 		window.list(LIST_SONGS_IN_PLAYLIST).selectItem(0);
 		window.list(LIST_SONGS_IN_STORE).requireNoSelection();
+		window.list(LIST_SONGS_IN_PLAYLIST).requireSelection(0);
 	}
 
 	@Test @GUITest
@@ -180,6 +181,7 @@ public class MusicStoreSwingViewTest extends AssertJSwingJUnitTestCase {
 		window.list(LIST_SONGS_IN_PLAYLIST).selectItem(0);
 		window.list(LIST_SONGS_IN_STORE).selectItem(0);
 		window.list(LIST_SONGS_IN_PLAYLIST).requireNoSelection();
+		window.list(LIST_SONGS_IN_STORE).requireSelection(0);
 	}
 
 


### PR DESCRIPTION
Fixed the bug related to changing playlist selection (previously, songs were not deleted correctly from the list).
Fixed bug related to single selection from either list (previously it was necessary to double-click on a song, first deselect the song in the other list, and then select the delete in the current list).